### PR TITLE
Add ADs for Heimdal updates to RFC6717 (kx509)

### DIFF
--- a/ad-type
+++ b/ad-type
@@ -44,6 +44,10 @@ easily be resolved based on the type of protocol operation.
 145  reserved (Microsoft; details unknown)
 512  AD-SIGNTICKET (MIT krb5 and Heimdal S4U2Self evidence ticket)
 513  AD-DIAMETER (draft-vanrein-krb5-authzdata-diameter-01 2)
+580  AD-ON-BEHALF-OF (Heimdal for RFC6717 updates)
+581  AD-BEARER-TOKEN-JWT (Heimdal for RFC6717 updates)
+582  AD-BEARER-TOKEN-SAML (Heimdal for RFC6717 updates)
+583  AD-BEARER-TOKEN-OIDC (Heimdal for RFC6717 updates)
 
 The following are outdated or deprecated assignments:
 


### PR DESCRIPTION
Heimdal will be adding an extension to RFC6717 (kx509) that allows for
clients to use JWT/SAML/OIDC for authentication, and also adds an
impersonation mechanism for trusted clients.