### PR TITLE
Add AD for Heimdal update to RFC6717 (kx509) (one more)

### DIFF
--- a/ad-type
+++ b/ad-type
@@ -48,6 +48,7 @@ easily be resolved based on the type of protocol operation.
 581  AD-BEARER-TOKEN-JWT (Heimdal for RFC6717 updates)
 582  AD-BEARER-TOKEN-SAML (Heimdal for RFC6717 updates)
 583  AD-BEARER-TOKEN-OIDC (Heimdal for RFC6717 updates)
+584  AD-CERT-REQ-AUTHORIZED (Heimdal for RFC6717 updates)
 
 The following are outdated or deprecated assignments:
 


### PR DESCRIPTION
Add AD-CERT-REQ-AUTHORIZED, whose payload is empty,
and whose presence indicates that the client has authorized all the
requested extensions (KU/EKUs/SANs) in the CSR for kx509.

The KDC must still validate that the client principal is trusted to make
such authorization decisions.